### PR TITLE
readme: Fix upstream XGU branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Examples for original Xbox using nxdk and xgu (name pending).
 ## Quick Guide
 This quick guide assumes you've already installed the dependencies for mainline nxdk, covered [here](https://github.com/XboxDev/nxdk/wiki/Install-the-Prerequisites).
 
-These examples are based on [an in-development branch of nxdk](https://github.com/dracc/nxdk/tree/xgu) containing the upcoming GPU middleware library, xgu.  
+These examples are based on [an in-development branch of nxdk](https://github.com/dracc/nxdk/tree/xgu_submodule) containing the upcoming GPU middleware library, xgu.  
 Clone both this repository and said branch to the same directory. There should be 2 folders exactly next to eachother: `nxdk` and `xbox-xgu-examples`.
 
-You can clone the in-dev branch like so: `git clone --recurse-submodules -b xgu https://github.com/dracc/nxdk`
+You can clone the in-dev branch like so: `git clone --recurse-submodules -b xgu_submodule https://github.com/dracc/nxdk`
 
 **IMPORTANT:** Before compiling any examples, a tiny adjustment currently needs to be made to `xgu.h` and `xgux.h` (in `nxdk/lib/xgu`) to prevent linker errors.  
 - In `xgu.h`, append `inline` to the end of `#define XGU_API`, near the top of the file.


### PR DESCRIPTION
I had a few mishaps in the recent past when interacting with `git`, the old XGU branch had its PR closed.
As the opportunity rised, I opted to rename the branch and do a few structural changes.

This PR aims to reflect said changes.